### PR TITLE
Backup load asset details endpoint

### DIFF
--- a/libs/Roblox/Roblox/Models/Result/Catalog/AssetDetailsCreator.cs
+++ b/libs/Roblox/Roblox/Models/Result/Catalog/AssetDetailsCreator.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace Roblox.Catalog;
+
+[DataContract]
+internal class AssetDetailsCreator
+{
+    [DataMember(Name = "CreatorTargetId")]
+    public long Id { get; set; }
+
+    [DataMember(Name = "Name")]
+    public string Name { get; set; }
+
+    [DataMember(Name = "CreatorType")]
+    public string Type { get; set; }
+}

--- a/libs/Roblox/Roblox/Models/Result/Catalog/AssetDetailsResult.cs
+++ b/libs/Roblox/Roblox/Models/Result/Catalog/AssetDetailsResult.cs
@@ -1,0 +1,50 @@
+﻿using System.Runtime.Serialization;
+using Roblox.Api;
+
+namespace Roblox.Catalog;
+
+[DataContract]
+internal class AssetDetailsResult
+{
+    [DataMember(Name = "TargetId")]
+    public long TargetId { get; set; }
+
+    [DataMember(Name = "ProductType")]
+    public string ProductType { get; set; }
+
+    [DataMember(Name = "AssetId")]
+    public long AssetId { get; set; }
+
+    [DataMember(Name = "ProductId")]
+    public long ProductId { get; set; }
+
+    [DataMember(Name = "Name")]
+    public string Name { get; set; }
+
+    [DataMember(Name = "Description")]
+    public string Description { get; set; }
+
+    [DataMember(Name = "AssetTypeId")]
+    public AssetType AssetType { get; set; }
+
+    [DataMember(Name = "Creator")]
+    public AssetDetailsCreator Creator { get; set; }
+
+    [DataMember(Name = "PriceInRobux")]
+    public long? Price { get; set; }
+
+    [DataMember(Name = "IsForSale")]
+    public bool IsForSale { get; set; }
+
+    [DataMember(Name = "IsPublicDomain")]
+    public bool Free { get; set; }
+
+    [DataMember(Name = "IsLimited")]
+    public bool IsLimited { get; set; }
+
+    [DataMember(Name = "IsLimitedUnique")]
+    public bool IsLimitedUnique { get; set; }
+
+    [DataMember(Name = "Remaining")]
+    public int? RemainingCount { get; set; }
+}

--- a/libs/Roblox/Roblox/Roblox.csproj
+++ b/libs/Roblox/Roblox/Roblox.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>1.6.2</VersionPrefix>
+    <VersionPrefix>1.7.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Sometimes an asset will claim to not exist, but it does exist. I found this endpoint on the economy API which will return the asset information anyway.

Example: https://www.roblox.com/catalog/7097623523/Content-Deleted