### PR TITLE
Throttle resale-data

### DIFF
--- a/libs/Roblox/Roblox/Enums/AssetType.cs
+++ b/libs/Roblox/Roblox/Enums/AssetType.cs
@@ -358,5 +358,25 @@ public enum AssetType
     /// <summary>
     /// MeshHiddenSurfaceRemoval
     /// </summary>
-    MeshHiddenSurfaceRemoval = 75
+    MeshHiddenSurfaceRemoval = 75,
+
+    /// <summary>
+    /// EyebrowAccessory
+    /// </summary>
+    EyebrowAccessory = 76,
+
+    /// <summary>
+    /// EyelashAccessory
+    /// </summary>
+    EyelashAccessory = 77,
+
+    /// <summary>
+    /// MoodAnimation
+    /// </summary>
+    MoodAnimation = 78,
+
+    /// <summary>
+    /// DynamicHead
+    /// </summary>
+    DynamicHead = 79,
 }

--- a/libs/Roblox/Roblox/Enums/AssetType.cs
+++ b/libs/Roblox/Roblox/Enums/AssetType.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Roblox.Api;
 
 /// <summary>
@@ -268,11 +270,13 @@ public enum AssetType
     /// <summary>
     /// EarAccessory
     /// </summary>
+    [Obsolete("None of these exist on Roblox, and it appears to be obsolete.")]
     EarAccessory = 57,
 
     /// <summary>
     /// EyeAccessory
     /// </summary>
+    [Obsolete("None of these exist on Roblox, and it appears to be obsolete.")]
     EyeAccessory = 58,
 
     /// <summary>

--- a/libs/Roblox/Roblox/Implementation/Clients/CatalogClient.cs
+++ b/libs/Roblox/Roblox/Implementation/Clients/CatalogClient.cs
@@ -7,8 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Roblox.Api;
-using Roblox.Models.Result.Catalog;
-using TixFactory.Queueing;
 
 namespace Roblox.Catalog;
 

--- a/libs/Roblox/Roblox/Implementation/TaskThrottler.cs
+++ b/libs/Roblox/Roblox/Implementation/TaskThrottler.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Roblox.Api;
+
+/// <inheritdoc cref="ITaskThrottler{TResult}"/>
+internal class TaskThrottler<TResult> : ITaskThrottler<TResult>, IDisposable
+{
+    private readonly ConcurrentQueue<(TaskCompletionSource<TResult> Task, Func<Task<TResult>> Action)> _TaskQueue = new();
+    private readonly Timer _TaskTimer;
+
+    /// <summary>
+    /// Initializes a new <see cref="TaskThrottler{TResult}"/>.
+    /// </summary>
+    /// <param name="throttle">How long to throttle the tasks for.</param>
+    public TaskThrottler(TimeSpan throttle)
+    {
+        _TaskTimer = new Timer(ProcessTaskAsync, state: null, throttle, throttle);
+    }
+
+    /// <inheritdoc cref="ITaskThrottler{TResult}.RunAsync"/>
+    public Task<TResult> RunAsync(Func<Task<TResult>> action, CancellationToken cancellationToken)
+    {
+        var completionSource = new TaskCompletionSource<TResult>(cancellationToken);
+        _TaskQueue.Enqueue((completionSource, action));
+        return completionSource.Task;
+    }
+
+    /// <inheritdoc cref="IDisposable.Dispose"/>
+    public void Dispose()
+    {
+        _TaskTimer?.Dispose();
+    }
+
+    private async void ProcessTaskAsync(object _)
+    {
+        if (!_TaskQueue.TryDequeue(out var task))
+        {
+            return;
+        }
+
+        try
+        {
+            var result = await task.Action();
+            task.Task.SetResult(result);
+        }
+        catch (Exception ex)
+        {
+            task.Task.SetException(ex);
+        }
+    }
+}

--- a/libs/Roblox/Roblox/Interfaces/ITaskThrottler.cs
+++ b/libs/Roblox/Roblox/Interfaces/ITaskThrottler.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Roblox.Api;
+
+/// <summary>
+/// Throttles tasks from executing.
+/// </summary>
+/// <remarks>
+/// The intention of this class is not to execute the tasks that run through it more than
+/// once per the specified time interval.
+/// </remarks>
+/// <typeparam name="TResult">The task result.</typeparam>
+public interface ITaskThrottler<TResult>
+{
+    /// <summary>
+    /// Runs a task, after the throttling period.
+    /// </summary>
+    /// <param name="action">The action to run in the task.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>The <see cref="Task{TResult}"/>, which will be run after the throttling period.</returns>
+    Task<TResult> RunAsync(Func<Task<TResult>> action, CancellationToken cancellationToken);
+}

--- a/libs/Roblox/Roblox/Models/Configuration/CatalogClientConfiguration.cs
+++ b/libs/Roblox/Roblox/Models/Configuration/CatalogClientConfiguration.cs
@@ -47,4 +47,9 @@ internal class CatalogClientConfiguration
     /// The maximum time to wait before sending a batched request.
     /// </summary>
     public TimeSpan MaxWaitTime { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// How long to wait between sending requests to load limited resale data.
+    /// </summary>
+    public TimeSpan ResaleDataThrottle { get; set; } = TimeSpan.FromSeconds(5);
 }

--- a/libs/Roblox/Roblox/Models/Result/Catalog/CatalogAssetResaleDataResult.cs
+++ b/libs/Roblox/Roblox/Models/Result/Catalog/CatalogAssetResaleDataResult.cs
@@ -1,6 +1,6 @@
 using System.Runtime.Serialization;
 
-namespace Roblox.Models.Result.Catalog;
+namespace Roblox.Catalog;
 
 /// <summary>
 /// Resale data from the economy API.

--- a/libs/Roblox/Roblox/Roblox.csproj
+++ b/libs/Roblox/Roblox/Roblox.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>1.8.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
# What

Calling out to `GetAssetAsync` often results in 429s from Roblox, when calling frequently with limited asset IDs.

We need to throttle how often we call out to the resale-data endpoint to prevent 429s.

# Unrelated

I found more asset types to add to the `AssetType` enum. And it appears two of them are no longer relevant.