### PR TITLE
Add IAuthenticationClient.RefreshAsync

### DIFF
--- a/libs/Roblox/Roblox/Constants/OAuthScope.cs
+++ b/libs/Roblox/Roblox/Constants/OAuthScope.cs
@@ -1,4 +1,4 @@
-namespace Roblox.Api;
+namespace Roblox.Authentication;
 
 /// <summary>
 /// Roblox OAuth scopes that exist.

--- a/libs/Roblox/Roblox/Constants/OAuthScope.cs
+++ b/libs/Roblox/Roblox/Constants/OAuthScope.cs
@@ -1,0 +1,20 @@
+namespace Roblox.Api;
+
+/// <summary>
+/// Roblox OAuth scopes that exist.
+/// </summary>
+public class OAuthScope
+{
+    /// <summary>
+    /// This scope is used for authenticating with Roblox.
+    /// </summary>
+    public const string OpenID = "openid";
+
+    /// <summary>
+    /// Scope for obtaining user information.
+    /// </summary>
+    /// <remarks>
+    /// https://apis.roblox.com/oauth/v1/userinfo
+    /// </remarks>
+    public const string Profile = "profile";
+}

--- a/libs/Roblox/Roblox/Implementation/Clients/AuthenticationClient.cs
+++ b/libs/Roblox/Roblox/Implementation/Clients/AuthenticationClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -11,10 +12,20 @@ using Roblox.Users;
 namespace Roblox.Authentication;
 
 /// <inheritdoc cref="IAuthenticationClient"/>
-public class AuthenticationClient : IAuthenticationClient
+public class AuthenticationClient : IAuthenticationClient, IDisposable
 {
+    /// <summary>
+    /// A dictionary, keyed by refresh token, of tokens that we have already refreshed.
+    /// </summary>
+    /// <remarks>
+    /// We cache the tokens that we have already refreshed here, in case we attempt to refresh them again.
+    /// We do this because once we use a refresh token it cannot be refreshed again.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, Task<LoginResult>> _RefreshCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly TimeSpan _CachePurgeInterval = TimeSpan.FromSeconds(30);
     private readonly HttpClient _HttpClient;
     private readonly string _Authorization;
+    private readonly Timer _CacheClearTimer;
 
     /// <summary>
     /// Initializes a new <seealso cref="AuthenticationClient"/>.
@@ -39,6 +50,7 @@ public class AuthenticationClient : IAuthenticationClient
 
         _HttpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _Authorization = authenticationSettings.Authorization;
+        _CacheClearTimer = new Timer(PurgeCache, null, _CachePurgeInterval, _CachePurgeInterval);
     }
 
     /// <inheritdoc cref="IAuthenticationClient.LoginAsync"/>
@@ -49,29 +61,98 @@ public class AuthenticationClient : IAuthenticationClient
             throw new ConfigurationException($"The app must have the Roblox.Authentication configuration filled in with {nameof(AuthenticationConfiguration.ClientId)} and {nameof(AuthenticationConfiguration.ClientSecret)} to use this method.");
         }
 
-        var tokenRequest = new HttpRequestMessage(HttpMethod.Post, new Uri($"{RobloxDomain.Apis}/oauth/v1/token"));
-        tokenRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", _Authorization);
-        tokenRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, new Uri($"{RobloxDomain.Apis}/oauth/v1/token"));
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", _Authorization);
+        httpRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
         {
             ["grant_type"] = "authorization_code",
             ["code"] = code
         });
-        var tokenResponse = await _HttpClient.SendApiRequestAsync<OAuthTokenResult>(tokenRequest, "oauth/v1/token", cancellationToken);
-
-        var userRequest = new HttpRequestMessage(HttpMethod.Get, new Uri($"{RobloxDomain.Apis}/oauth/v1/userinfo"));
-        userRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenResponse.AccessToken);
-        var userResponse = await _HttpClient.SendApiRequestAsync<UserInfoResult>(userRequest, "oauth/v1/userinfo", cancellationToken);
+        var httpResponse = await _HttpClient.SendApiRequestAsync<OAuthTokenResult>(httpRequest, "oauth/v1/token", cancellationToken);
+        var user = await GetUserDataAsync(httpResponse, cancellationToken);
 
         return new LoginResult
         {
-            AccessToken = tokenResponse.AccessToken,
-            RefreshToken = tokenResponse.RefreshToken,
-            User = new UserResult
-            {
-                Id = userResponse.Id,
-                Name = userResponse.Name,
-                DisplayName = userResponse.DisplayName
-            }
+            AccessToken = httpResponse.AccessToken,
+            RefreshToken = httpResponse.RefreshToken,
+            AccessTokenExpiration = httpResponse.AccessTokenExpiration,
+            Scopes = httpResponse.Scopes,
+            User = user
         };
+    }
+
+    /// <inheritdoc cref="IAuthenticationClient.RefreshAsync"/>
+    public Task<LoginResult> RefreshAsync(string refreshToken, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_Authorization))
+        {
+            throw new ConfigurationException($"The app must have the Roblox.Authentication configuration filled in with {nameof(AuthenticationConfiguration.ClientId)} and {nameof(AuthenticationConfiguration.ClientSecret)} to use this method.");
+        }
+
+        return _RefreshCache.GetOrAdd(refreshToken, t => UncachedRefreshAsync(t, cancellationToken));
+    }
+
+    /// <inheritdoc cref="IDisposable.Dispose"/>
+    public void Dispose()
+    {
+        _CacheClearTimer?.Dispose();
+    }
+
+    private async Task<LoginResult> UncachedRefreshAsync(string refreshToken, CancellationToken cancellationToken)
+    {
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, new Uri($"{RobloxDomain.Apis}/oauth/v1/token"));
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", _Authorization);
+        httpRequest.Content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken
+        });
+        var httpResponse = await _HttpClient.SendApiRequestAsync<OAuthTokenResult>(httpRequest, "oauth/v1/token", cancellationToken);
+        var user = await GetUserDataAsync(httpResponse, cancellationToken);
+
+        return new LoginResult
+        {
+            AccessToken = httpResponse.AccessToken,
+            RefreshToken = httpResponse.RefreshToken,
+            AccessTokenExpiration = httpResponse.AccessTokenExpiration,
+            Scopes = httpResponse.Scopes,
+            User = user
+        };
+    }
+
+    private async Task<UserResult> GetUserDataAsync(OAuthTokenResult authenticationResult, CancellationToken cancellationToken)
+    {
+        // HACK: We're taking advantage of that userinfo and token/introspect both return the user ID as "sub", so we can deserialize it into the same model.
+        var userInfoPath = authenticationResult.Scopes.Contains(OAuthScope.Profile) ? "oauth/v1/userinfo" : "oauth/v1/token/introspect";
+        var httpRequest = new HttpRequestMessage(HttpMethod.Get, new Uri($"{RobloxDomain.Apis}/{userInfoPath}"));
+        httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authenticationResult.AccessToken);
+
+        var response = await _HttpClient.SendApiRequestAsync<UserInfoResult>(httpRequest, userInfoPath, cancellationToken);
+
+        return new UserResult
+        {
+            Id = response.Id,
+            Name = response.Name,
+            DisplayName = response.DisplayName
+        };
+    }
+
+    private void PurgeCache(object state)
+    {
+        foreach (var (refreshToken, result) in _RefreshCache.ToArray())
+        {
+            if (result.IsFaulted)
+            {
+                // Don't keep the failed refreshes around.
+                _RefreshCache.TryRemove(refreshToken, out _);
+                continue;
+            }
+
+            if (result.IsCompletedSuccessfully && result.Result.AccessTokenExpiration < DateTime.UtcNow)
+            {
+                // The access token for this one is already expired, and for now, we're using this as the cache expiry period.
+                _RefreshCache.TryRemove(refreshToken, out _);
+            }
+        }
     }
 }

--- a/libs/Roblox/Roblox/Interfaces/Clients/IAuthenticationClient.cs
+++ b/libs/Roblox/Roblox/Interfaces/Clients/IAuthenticationClient.cs
@@ -21,4 +21,15 @@ public interface IAuthenticationClient
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
     /// <returns>The result of logging in.</returns>
     Task<LoginResult> LoginAsync(string code, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Refreshes an authentication session, using the refresh token.
+    /// </summary>
+    /// <remarks>
+    /// Requires the openid + profile scopes.
+    /// </remarks>
+    /// <param name="refreshToken">The refresh token.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+    /// <returns>The result of logging in, with the refreshed session.</returns>
+    Task<LoginResult> RefreshAsync(string refreshToken, CancellationToken cancellationToken);
 }

--- a/libs/Roblox/Roblox/Interfaces/Clients/IAuthenticationClient.cs
+++ b/libs/Roblox/Roblox/Interfaces/Clients/IAuthenticationClient.cs
@@ -15,7 +15,8 @@ public interface IAuthenticationClient
     /// Logs in a user with their authorization code.
     /// </summary>
     /// <remarks>
-    /// Requires the openid + profile scopes.
+    /// If the <see cref="OAuthScope.Profile"/> scope is available, it will be used to fetch data for <see cref="LoginResult.User"/>.
+    /// If it is unavailable, only the <see cref="UserInfoResult.Id"/> field will be populated.
     /// </remarks>
     /// <param name="code">The authorization code.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
@@ -26,7 +27,8 @@ public interface IAuthenticationClient
     /// Refreshes an authentication session, using the refresh token.
     /// </summary>
     /// <remarks>
-    /// Requires the openid + profile scopes.
+    /// If the <see cref="OAuthScope.Profile"/> scope is available, it will be used to fetch data for <see cref="LoginResult.User"/>.
+    /// If it is unavailable, only the <see cref="UserInfoResult.Id"/> field will be populated.
     /// </remarks>
     /// <param name="refreshToken">The refresh token.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>

--- a/libs/Roblox/Roblox/Models/Result/Authentication/LoginResult.cs
+++ b/libs/Roblox/Roblox/Models/Result/Authentication/LoginResult.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Roblox.Users;
 
@@ -12,18 +14,39 @@ public class LoginResult
     /// <summary>
     /// The access token, which can be used immediately to make requests.
     /// </summary>
-    [DataMember(Name = "accessToken")]
-    public string AccessToken { get; set; }
+    [DataMember(Name = "access_token")]
+    public string AccessToken { get; internal set; }
 
     /// <summary>
     /// The refresh token, which can be used to obtain an access token.
     /// </summary>
-    [DataMember(Name = "refreshToken")]
-    public string RefreshToken { get; set; }
+    [DataMember(Name = "refresh_token")]
+    public string RefreshToken { get; internal set; }
+
+    /// <summary>
+    /// When the access token will expire.
+    /// </summary>
+    [DataMember(Name = "expiration")]
+    public DateTime AccessTokenExpiration { get; internal set; }
 
     /// <summary>
     /// The user we logged in as.
     /// </summary>
     [DataMember(Name = "user")]
-    public UserResult User { get; set; }
+    public UserResult User { get; internal set; }
+
+    /// <summary>
+    /// The scopes associated with the token.
+    /// </summary>
+    /// <remarks>
+    /// This property exists for serialization.
+    /// </remarks>
+    [DataMember(Name = "scopes")]
+    public string RawScopes => string.Join(' ', Scopes);
+
+    /// <summary>
+    /// The scopes associated with the token.
+    /// </summary>
+    [IgnoreDataMember]
+    public ISet<string> Scopes { get; internal set; }
 }

--- a/libs/Roblox/Roblox/Models/Result/Authentication/OAuthTokenResult.cs
+++ b/libs/Roblox/Roblox/Models/Result/Authentication/OAuthTokenResult.cs
@@ -1,13 +1,93 @@
+using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Roblox.Authentication;
 
+/// <summary>
+/// The result of requesting for an access token/refresh token.
+/// </summary>
+/// <remarks>
+/// See also: https://devforum.roblox.com/t/introduction-to-oauth-20/1940062#tokens-2
+/// </remarks>
 [DataContract]
 internal class OAuthTokenResult
 {
+    /// <summary>
+    /// We have some leeway on the expiration, to account for latency, and the ability to actually use the token.
+    /// </summary>
+    /// <remarks>
+    /// This exists to ensure when the consumers of this library say "is the token expired?" they can use the token
+    /// for up to this much extra time, to ensure that when they send their requests with it, they will succeed.
+    /// </remarks>
+    private static readonly TimeSpan _ExpirationLeeway = TimeSpan.FromMinutes(1);
+    private ISet<string> _Scopes = new HashSet<string>();
+
+    /// <summary>
+    /// The Bearer token, which can be used to send requests to Roblox on behalf of the user.
+    /// </summary>
     [DataMember(Name = "access_token")]
     public string AccessToken { get; set; }
 
+    /// <summary>
+    /// The refresh token, which can be used to obtain an <see cref="AccessToken"/>.
+    /// </summary>
+    /// <remarks>
+    /// As documented, this should last for up to 6 months.
+    /// But it is also mutable, and a new one will be returned every refresh.
+    /// </remarks>
     [DataMember(Name = "refresh_token")]
     public string RefreshToken { get; set; }
+
+    /// <summary>
+    /// How long, in seconds, the access token will be valid for.
+    /// </summary>
+    /// <remarks>
+    /// This property exists for deserialization.
+    /// </remarks>
+    [DataMember(Name = "expires_in")]
+    public double ExpiresIn
+    {
+        private get
+        {
+            var expiration = AccessTokenExpiration - DateTime.UtcNow;
+            return expiration.TotalSeconds;
+        }
+        set => AccessTokenExpiration = DateTime.UtcNow.AddSeconds(value - _ExpirationLeeway.TotalSeconds);
+    }
+
+    /// <summary>
+    /// When the access token will expire.
+    /// </summary>
+    [DataMember(Name = "expiration")]
+    public DateTime AccessTokenExpiration { get; private set; }
+
+    /// <summary>
+    /// The scopes associated with the token.
+    /// </summary>
+    /// <remarks>
+    /// This property exists for deserialization.
+    /// </remarks>
+    [DataMember(Name = "scopes")]
+    public string RawScopes
+    {
+        get => string.Join(' ', _Scopes);
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                _Scopes = new HashSet<string>();
+            }
+            else
+            {
+                _Scopes = new HashSet<string>(value.Split(' '), StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The scopes associated with the token.
+    /// </summary>
+    [IgnoreDataMember]
+    public ISet<string> Scopes => _Scopes;
 }

--- a/libs/Roblox/Roblox/Roblox.csproj
+++ b/libs/Roblox/Roblox/Roblox.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>1.14.0</VersionPrefix>
+    <VersionPrefix>1.15.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Adding the ability to refresh a refresh token, to gain a new access token.

Notable: When a refresh token is redeemed for an access token, the refresh token is immediately expired.