### PR TITLE
Handle expired refresh tokens "gracefully"

### DIFF
--- a/libs/Roblox/Roblox/Exceptions/RobloxApiException.cs
+++ b/libs/Roblox/Roblox/Exceptions/RobloxApiException.cs
@@ -49,7 +49,18 @@ public class RobloxApiException : Exception
         : this(ParseErrorCodeResult(httpResponse), httpRequest, httpResponse)
     {
         StatusCode = httpResponse.StatusCode;
+    }
 
+    /// <summary>
+    /// Makes a copy of <see cref="RobloxApiException"/>.
+    /// </summary>
+    /// <param name="copyFromExtension">The <see cref="RobloxApiException"/> to copy from.</param>
+    public RobloxApiException(RobloxApiException copyFromExtension)
+        : this(copyFromExtension.Message, copyFromExtension.InnerException)
+    {
+        StatusCode = copyFromExtension.StatusCode;
+        ErrorCode = copyFromExtension.ErrorCode;
+        ErrorMessage = copyFromExtension.ErrorMessage;
     }
 
     private RobloxApiException(ApiErrorCodeResult errorCodeResult, HttpRequestMessage httpRequest, HttpResponseMessage httpResponse)

--- a/libs/Roblox/Roblox/Exceptions/RobloxUnauthenticatedException.cs
+++ b/libs/Roblox/Roblox/Exceptions/RobloxUnauthenticatedException.cs
@@ -16,4 +16,13 @@ public class RobloxUnauthenticatedException : RobloxApiException
         : base(httpRequest, httpResponse)
     {
     }
+
+    /// <summary>
+    /// Converts a <see cref="RobloxApiException"/> to a <see cref="RobloxUnauthenticatedException"/>.
+    /// </summary>
+    /// <param name="originalException">The <see cref="RobloxApiException"/>.</param>
+    public RobloxUnauthenticatedException(RobloxApiException originalException)
+        : base(originalException)
+    {
+    }
 }

--- a/libs/Roblox/Roblox/Implementation/Clients/AuthenticationClient.cs
+++ b/libs/Roblox/Roblox/Implementation/Clients/AuthenticationClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -168,6 +169,10 @@ public class AuthenticationClient : IAuthenticationClient, IDisposable
                 Scopes = httpResponse.Scopes,
                 User = user
             };
+        }
+        catch (RobloxApiException e) when (e.StatusCode == HttpStatusCode.BadRequest && e.ErrorCode == "invalid_grant")
+        {
+            throw new RobloxUnauthenticatedException(e);
         }
         catch (Exception)
         {

--- a/libs/Roblox/Roblox/Roblox.csproj
+++ b/libs/Roblox/Roblox/Roblox.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <VersionPrefix>1.19.0</VersionPrefix>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />


### PR DESCRIPTION
Right now, an expired refresh token will throw:
```
Unhandled exception caught by middleware. Request to Roblox failed.
	Status Code: BadRequest
	Url: https://apis.roblox.com/oauth/v1/token
	Error (invalid_grant): Token has expired
   at Roblox.Api.HttpClientExtensions.SendApiRequestAsync[TResult](HttpClient httpClient, HttpRequestMessage httpRequest, String endpoint, CancellationToken cancellationToken)
   at Roblox.Authentication.AuthenticationClient.UncachedRefreshAsync(String refreshToken, CancellationToken cancellationToken)
```

If a token has expired, we should treat it the same way we should wrap it in a `RobloxUnauthenticatedException`, which we throw when a request to Roblox is unauthenticated.